### PR TITLE
Refactor controller order processing with strategy pattern

### DIFF
--- a/src/main/java/com/nimbleways/springboilerplate/contollers/MyController.java
+++ b/src/main/java/com/nimbleways/springboilerplate/contollers/MyController.java
@@ -1,16 +1,8 @@
 package com.nimbleways.springboilerplate.contollers;
 
 import com.nimbleways.springboilerplate.dto.product.ProcessOrderResponse;
-import com.nimbleways.springboilerplate.entities.Order;
-import com.nimbleways.springboilerplate.entities.Product;
-import com.nimbleways.springboilerplate.repositories.OrderRepository;
-import com.nimbleways.springboilerplate.repositories.ProductRepository;
-import com.nimbleways.springboilerplate.services.implementations.ProductService;
+import com.nimbleways.springboilerplate.services.implementations.OrderService;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -23,53 +15,17 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/orders")
 public class MyController {
-    @Autowired
-    private ProductService ps;
+
+    private final OrderService orderService;
 
     @Autowired
-    private ProductRepository pr;
-
-    @Autowired
-    private OrderRepository or;
+    public MyController(OrderService orderService) {
+        this.orderService = orderService;
+    }
 
     @PostMapping("{orderId}/processOrder")
     @ResponseStatus(HttpStatus.OK)
     public ProcessOrderResponse processOrder(@PathVariable Long orderId) {
-        Order order = or.findById(orderId).get();
-        System.out.println(order);
-        List<Long> ids = new ArrayList<>();
-        ids.add(orderId);
-        Set<Product> products = order.getItems();
-        for (Product p : products) {
-            if (p.getType().equals("NORMAL")) {
-                if (p.getAvailable() > 0) {
-                    p.setAvailable(p.getAvailable() - 1);
-                    pr.save(p);
-                } else {
-                    int leadTime = p.getLeadTime();
-                    if (leadTime > 0) {
-                        ps.notifyDelay(leadTime, p);
-                    }
-                }
-            } else if (p.getType().equals("SEASONAL")) {
-                // Add new season rules
-                if ((LocalDate.now().isAfter(p.getSeasonStartDate()) && LocalDate.now().isBefore(p.getSeasonEndDate())
-                        && p.getAvailable() > 0)) {
-                    p.setAvailable(p.getAvailable() - 1);
-                    pr.save(p);
-                } else {
-                    ps.handleSeasonalProduct(p);
-                }
-            } else if (p.getType().equals("EXPIRABLE")) {
-                if (p.getAvailable() > 0 && p.getExpiryDate().isAfter(LocalDate.now())) {
-                    p.setAvailable(p.getAvailable() - 1);
-                    pr.save(p);
-                } else {
-                    ps.handleExpiredProduct(p);
-                }
-            }
-        }
-
-        return new ProcessOrderResponse(order.getId());
+        return orderService.processOrder(orderId);
     }
 }

--- a/src/main/java/com/nimbleways/springboilerplate/services/implementations/OrderService.java
+++ b/src/main/java/com/nimbleways/springboilerplate/services/implementations/OrderService.java
@@ -1,0 +1,40 @@
+package com.nimbleways.springboilerplate.services.implementations;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.nimbleways.springboilerplate.dto.product.ProcessOrderResponse;
+import com.nimbleways.springboilerplate.entities.Order;
+import com.nimbleways.springboilerplate.entities.Product;
+import com.nimbleways.springboilerplate.repositories.OrderRepository;
+import com.nimbleways.springboilerplate.services.strategy.ProductProcessingStrategy;
+
+@Service
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final Map<String, ProductProcessingStrategy> strategyMap;
+
+    @Autowired
+    public OrderService(OrderRepository orderRepository,
+                        List<ProductProcessingStrategy> strategies) {
+        this.orderRepository = orderRepository;
+        this.strategyMap = strategies.stream()
+                                     .collect(Collectors.toMap(ProductProcessingStrategy::getType, s -> s));
+    }
+
+    public ProcessOrderResponse processOrder(Long orderId) {
+        Order order = orderRepository.findById(orderId).get();
+        for (Product product : order.getItems()) {
+            ProductProcessingStrategy strategy = strategyMap.get(product.getType());
+            if (strategy != null) {
+                strategy.process(product);
+            }
+        }
+        return new ProcessOrderResponse(order.getId());
+    }
+}

--- a/src/main/java/com/nimbleways/springboilerplate/services/strategy/ExpirableProductProcessingStrategy.java
+++ b/src/main/java/com/nimbleways/springboilerplate/services/strategy/ExpirableProductProcessingStrategy.java
@@ -1,0 +1,37 @@
+package com.nimbleways.springboilerplate.services.strategy;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+import com.nimbleways.springboilerplate.entities.Product;
+import com.nimbleways.springboilerplate.repositories.ProductRepository;
+import com.nimbleways.springboilerplate.services.implementations.ProductService;
+
+@Component
+public class ExpirableProductProcessingStrategy implements ProductProcessingStrategy {
+
+    private final ProductService productService;
+    private final ProductRepository productRepository;
+
+    public ExpirableProductProcessingStrategy(ProductService productService,
+                                              ProductRepository productRepository) {
+        this.productService = productService;
+        this.productRepository = productRepository;
+    }
+
+    @Override
+    public String getType() {
+        return "EXPIRABLE";
+    }
+
+    @Override
+    public void process(Product product) {
+        if (product.getAvailable() > 0 && product.getExpiryDate().isAfter(LocalDate.now())) {
+            product.setAvailable(product.getAvailable() - 1);
+            productRepository.save(product);
+        } else {
+            productService.handleExpiredProduct(product);
+        }
+    }
+}

--- a/src/main/java/com/nimbleways/springboilerplate/services/strategy/NormalProductProcessingStrategy.java
+++ b/src/main/java/com/nimbleways/springboilerplate/services/strategy/NormalProductProcessingStrategy.java
@@ -1,0 +1,35 @@
+package com.nimbleways.springboilerplate.services.strategy;
+
+import org.springframework.stereotype.Component;
+
+import com.nimbleways.springboilerplate.entities.Product;
+import com.nimbleways.springboilerplate.repositories.ProductRepository;
+import com.nimbleways.springboilerplate.services.implementations.ProductService;
+
+@Component
+public class NormalProductProcessingStrategy implements ProductProcessingStrategy {
+
+    private final ProductService productService;
+    private final ProductRepository productRepository;
+
+    public NormalProductProcessingStrategy(ProductService productService,
+                                           ProductRepository productRepository) {
+        this.productService = productService;
+        this.productRepository = productRepository;
+    }
+
+    @Override
+    public String getType() {
+        return "NORMAL";
+    }
+
+    @Override
+    public void process(Product product) {
+        if (product.getAvailable() > 0) {
+            product.setAvailable(product.getAvailable() - 1);
+            productRepository.save(product);
+        } else if (product.getLeadTime() > 0) {
+            productService.notifyDelay(product.getLeadTime(), product);
+        }
+    }
+}

--- a/src/main/java/com/nimbleways/springboilerplate/services/strategy/ProductProcessingStrategy.java
+++ b/src/main/java/com/nimbleways/springboilerplate/services/strategy/ProductProcessingStrategy.java
@@ -1,0 +1,8 @@
+package com.nimbleways.springboilerplate.services.strategy;
+
+import com.nimbleways.springboilerplate.entities.Product;
+
+public interface ProductProcessingStrategy {
+    String getType();
+    void process(Product product);
+}

--- a/src/main/java/com/nimbleways/springboilerplate/services/strategy/SeasonalProductProcessingStrategy.java
+++ b/src/main/java/com/nimbleways/springboilerplate/services/strategy/SeasonalProductProcessingStrategy.java
@@ -1,0 +1,40 @@
+package com.nimbleways.springboilerplate.services.strategy;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Component;
+
+import com.nimbleways.springboilerplate.entities.Product;
+import com.nimbleways.springboilerplate.repositories.ProductRepository;
+import com.nimbleways.springboilerplate.services.implementations.ProductService;
+
+@Component
+public class SeasonalProductProcessingStrategy implements ProductProcessingStrategy {
+
+    private final ProductService productService;
+    private final ProductRepository productRepository;
+
+    public SeasonalProductProcessingStrategy(ProductService productService,
+                                             ProductRepository productRepository) {
+        this.productService = productService;
+        this.productRepository = productRepository;
+    }
+
+    @Override
+    public String getType() {
+        return "SEASONAL";
+    }
+
+    @Override
+    public void process(Product product) {
+        LocalDate now = LocalDate.now();
+        if (now.isAfter(product.getSeasonStartDate()) &&
+            now.isBefore(product.getSeasonEndDate()) &&
+            product.getAvailable() > 0) {
+            product.setAvailable(product.getAvailable() - 1);
+            productRepository.save(product);
+        } else {
+            productService.handleSeasonalProduct(product);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `ProductProcessingStrategy` and implementations for normal, seasonal and expirable products
- update `OrderService` to delegate item handling to injected strategies
- keep `MyController` delegating to the service

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6857f3b8fa98833293072fcd04c28dca